### PR TITLE
fix: change endpoint for the project invitation to share

### DIFF
--- a/src/collaboard/projects.ts
+++ b/src/collaboard/projects.ts
@@ -103,7 +103,7 @@ export const shareProject = async (
         UniqueDeviceId: uuid,
         MemberPermission,
         ValidForMinutes: 60,
-        InvitationUrl: `${webappUrl}/acceptProjectInvitation`
+        InvitationUrl: `${webappUrl}/share`
       })
     }
   )


### PR DESCRIPTION
The endpoint changed from `/acceptProjectInvitation` to `/share`.