### PR TITLE
feat: create one time token for each invitation link

### DIFF
--- a/src/collaboard/projects.ts
+++ b/src/collaboard/projects.ts
@@ -8,6 +8,7 @@ import type { GetProjectResponse } from '../types/responses/GetProjectResponse'
 import type { ProjectInfo } from '../types/ProjectInfo'
 import type { CreateProjectResponse } from '../types/responses/CreateProjectResponse'
 import type { ShareProjectResponse } from '../types/responses/ShareProjectResponse'
+import type { CreateOneTimeTokenResponse } from '../types/responses/CreateOneTimeTokenResponse'
 
 const baseUrl: string = config.apiUrl
 const webappUrl: string = config.webappUrl
@@ -138,6 +139,28 @@ export const shareProject = async (
 
 export const stopSharingProject = (): void => {
   isSharing = false
+}
+
+export const createOneTimeToken = async (): Promise<string> => {
+  const token = getAccessToken()
+
+  const response = await fetch(
+    `${baseUrl}/public/api/public/v2.0/collaborationhub/auth/onetimetoken`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }
+  )
+  if (response.status !== Number(HttpStatusCode.Ok)) {
+    const errorMessage = 'Failed to create one time token'
+    throw new Error(errorMessage)
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- We trust the response
+    const data = (await response.json()) as CreateOneTimeTokenResponse
+    return data.Result
+  }
 }
 
 const getErrorDescription = (code: number): string => {

--- a/src/types/responses/CreateOneTimeTokenResponse.ts
+++ b/src/types/responses/CreateOneTimeTokenResponse.ts
@@ -1,0 +1,6 @@
+import type { CollaboardErrorCode } from '../CollaboardErrorCode'
+
+export interface CreateOneTimeTokenResponse {
+  Result: string
+  ErrorCode: CollaboardErrorCode
+}

--- a/vite.json
+++ b/vite.json
@@ -1,5 +1,5 @@
 {
-  "infinityUrl": "https://nightly.pexip.com",
+  "infinityUrl": "https://pexipdemo.com",
   "port": 5173,
   "brandingPath": "/local-plugin"
 }


### PR DESCRIPTION
One need to attach a one time token that will log in automatically when loading the pop up. We have three ways to open the pop-up:

- Confirmation prompt for the person that shared the whiteboard.
- Notification prompt for a person that received the whiteboard invitation.
- Button in the toolbar for both.